### PR TITLE
Mitigate errors when receiving requests with empty HTTP request bodies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 development
 ===========
 - Improve installation documentation
+- Mitigate ``400 Bad Request`` responses when receiving GET requests with
+  empty HTTP request bodies but still setting ``Content-Type: application/json``.
+  Thanks for the report, @byteptr and @MichielKE!
 
 
 2022-01-22 0.2.0

--- a/grafana_pandas_datasource/service.py
+++ b/grafana_pandas_datasource/service.py
@@ -17,8 +17,8 @@ methods = ('GET', 'POST')
 
 @pandas_component.route('/', methods=methods)
 @cross_origin()
-def hello_world():
-    print(request.headers, request.get_json())
+def test_datasource():
+    print(request.headers, request.get_json(silent=True))
     return 'Grafana pandas datasource: Serve NumPy data via pandas data frames to Grafana. ' \
            'For documentation, see <a href="https://github.com/panodata/grafana-pandas-datasource">https://github.com/panodata/grafana-pandas-datasource</a>.'
 
@@ -107,7 +107,7 @@ def query_annotations():
 @pandas_component.route('/panels', methods=methods)
 @cross_origin()
 def get_panel():
-    print(request.headers, request.get_json())
+    print(request.headers, request.args)
     req = request.args
 
     ts_range = {'$gt': pd.Timestamp(int(req['from']), unit='ms').to_pydatetime(),


### PR DESCRIPTION
Hi there,

at https://github.com/panodata/grafana-pandas-datasource/issues/9#issuecomment-1029537267, we discovered that there is an issue with Simple JSON Datasource sending HTTP requests with empty HTTP request bodies, but still having the `Content-Type: application/json` HTTP header present. Those requests will make Flask croak like:

```
$ echo "" | http localhost:3003 Content-Type:application/json
HTTP/1.0 400 BAD REQUEST

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>400 Bad Request</title>
<h1>Bad Request</h1>
<p>Failed to decode JSON object: Expecting value: line 1 column 1 (char 0)</p>
```

This patch fixes the problem, like @ThiefMaster suggested at https://github.com/pallets/flask/pull/1940#issuecomment-229936524:

> You can catch the exception or use `silent=True`.

In this manner, it will also resolve #7.

With kind regards,
Andreas.

/cc @byteptr, @MichielKE